### PR TITLE
Improve error for instances with authorized fetch enabled

### DIFF
--- a/templates/forbidden.html
+++ b/templates/forbidden.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %}Custom emoji list for {{ domain }}{% endblock title %}
+{% block body %}
+<p><b>{{ domain }}</b> doesn't allow access to the <code>v1/custom_emojis</code> endpoint. :(</p>
+{% endblock body %}


### PR DESCRIPTION
When authorized fetch mode is enabled on mastodon https://docs.joinmastodon.org/admin/config/#authorized_fetch, mastodon will signatures for endpoints which are used for activitypub or an authenticated user for internal endpoints. Since custom emojis is internal, it cannot be accessed without a logged-in user.
This improves the error to make it more clear.

This is related to #14.