### PR TITLE
Apply loading=lazy attribute

### DIFF
--- a/templates/emojo.html
+++ b/templates/emojo.html
@@ -9,14 +9,14 @@
     {% if show_animated %}
         {% for emoj in emojo %}
         <div>
-            <dt><img src="{{ emoj.url }}" alt=":{{ emoj.shortcode }}:"></dt>
+            <dt><img src="{{ emoj.url }}" alt=":{{ emoj.shortcode }}:" loading=lazy></dt>
             <dd>:{{ emoj.shortcode }}:</dd>
         </div>
         {% endfor %}
     {% else %}
         {% for emoj in emojo %}
         <div>
-            <dt><img src="{{ emoj.static_url }}" alt=":{{ emoj.shortcode }}:"></dt>
+            <dt><img src="{{ emoj.static_url }}" alt=":{{ emoj.shortcode }}:" loading=lazy></dt>
             <dd>:{{ emoj.shortcode }}:</dd>
         </div>
         {% endfor %}


### PR DESCRIPTION
Hopefully improves performance, as loading all images at once (Even those not visible to the screen) tanks the browser to death if an instance has an insane amount of emojos...

Fixes #21?